### PR TITLE
wip: migrate to new deno apis

### DIFF
--- a/ignore_test.ts
+++ b/ignore_test.ts
@@ -1,8 +1,8 @@
 // Copyright 2020 denolib maintainers. MIT license.
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-import { test, runIfMain } from "https://deno.land/std/testing/mod.ts";
 import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
 import { parse } from "./ignore.ts";
+const { test } = Deno;
 
 const testCases = [
   {
@@ -78,5 +78,3 @@ test({
     }
   }
 });
-
-runIfMain(import.meta);

--- a/main.ts
+++ b/main.ts
@@ -242,16 +242,12 @@ async function checkSourceFiles(
 ): Promise<void> {
   const checks: Array<Promise<boolean>> = [];
 
-  // TODO(eankeen): ensure this works / cleanup
-  // for await (const { filename } of files) {
   for await (const { path: filename } of files) {
-    console.log('AAA', filename)
     const parser = selectParser(filename);
     if (parser) {
       checks.push(checkFile(filename, parser, prettierOpts));
     }
   }
-  console.log('FFF', files)
 
   const results = await Promise.all(checks);
 
@@ -274,7 +270,6 @@ async function formatSourceFiles(
 ): Promise<void> {
   const formats: Array<Promise<void>> = [];
 
-  // TODO(eankeen): ensure this works
   for await (const { path: filename } of files) {
     const parser = selectParser(filename);
     if (parser) {
@@ -387,7 +382,6 @@ async function autoResolveConfig(): Promise<PrettierBuildInOptions | undefined> 
 
   const files = await Deno.readDir(".");
 
-  // TODO(eankeen): remove ts-ignore
   for await (const f of files) {
     if (f.isFile && configFileNamesMap[f.name!]) {
       const c = await resolveConfig(f.name!);
@@ -477,7 +471,6 @@ async function resolveConfig(
 async function autoResolveIgnoreFile(): Promise<Set<string>> {
   const files = await Deno.readDir(".");
 
-  // TODO(eankeen): remove ts-ignore
   for await (const f of files) {
     if (f.isFile && f.name === ".prettierignore") {
       return await resolveIgnoreFile(f.name);

--- a/main_test.ts
+++ b/main_test.ts
@@ -58,18 +58,21 @@ test({
       join(tempDir, "4.tsx"),
     ];
 
+    // TODO(eankeen): cleanup
     let p = await run([...cmd, "--check", ...files]);
+    console.log("DOO", p.stdout)
     assertEquals(p.code, 1);
     assertEquals(normalizeOutput(p.stdout), "Some files are not formatted");
 
+    console.log("FILES", files)
     p = await run([...cmd, "--write", ...files]);
     assertEquals(p.code, 0);
     assertEquals(
       normalizeOutput(p.stdout),
       normalizeOutput(`Formatting ${tempDir}/0.ts
-    Formatting ${tempDir}/1.js
-    Formatting ${tempDir}/3.jsx
-    Formatting ${tempDir}/4.tsx
+Formatting ${tempDir}/1.js
+Formatting ${tempDir}/3.jsx
+Formatting ${tempDir}/4.tsx
     `),
     );
 
@@ -98,9 +101,9 @@ test({
     assertEquals(
       normalizeOutput(p.stdout),
       normalizeOutput(`Formatting ${tempDir}/bar/0.ts
-    Formatting ${tempDir}/bar/1.js
-    Formatting ${tempDir}/foo/0.ts
-    Formatting ${tempDir}/foo/1.js`),
+Formatting ${tempDir}/bar/1.js
+Formatting ${tempDir}/foo/0.ts
+Formatting ${tempDir}/foo/1.js`),
     );
 
     p = await run([...cmd, "--check", ...dirs]);
@@ -129,7 +132,7 @@ test({
     assertEquals(
       normalizeSourceCode(await getSourceCode(file0)),
       `console.log(0)
-    console.log([function foo() {}, function baz() {}, a => {}])
+console.log([function foo() {}, function baz() {}, a => {}])
     `,
     );
 
@@ -145,11 +148,11 @@ test({
     assertEquals(
       normalizeSourceCode(await getSourceCode(file0)),
       `console.log(0);
-    console.log([
-        function foo() {},
-        function baz() {},
-        a => {}
-    ]);
+console.log([
+    function foo() {},
+    function baz() {},
+    a => {}
+]);
     `,
     );
 
@@ -157,11 +160,11 @@ test({
     assertEquals(
       normalizeSourceCode(await getSourceCode(file0)),
       `console.log(0);
-    console.log([
-      function foo() {},
-      function baz() {},
-      a => {}
-    ]);
+console.log([
+  function foo() {},
+  function baz() {},
+  a => {}
+]);
     `,
     );
 
@@ -184,11 +187,11 @@ test({
     assertEquals(
       normalizeSourceCode(await getSourceCode(file0)),
       `console.log(0);
-    console.log([
-      function foo() {},
-      function baz() {},
-      a => {},
-    ]);
+console.log([
+  function foo() {},
+  function baz() {},
+  a => {},
+]);
     `,
     );
 
@@ -203,7 +206,7 @@ test({
     assertEquals(
       normalizeSourceCode(await getSourceCode(file0)),
       `console.log(0);
-    console.log([function foo() {}, function baz() {}, (a) => {}]);
+console.log([function foo() {}, function baz() {}, (a) => {}]);
     `,
     );
 

--- a/main_test.ts
+++ b/main_test.ts
@@ -58,13 +58,10 @@ test({
       join(tempDir, "4.tsx"),
     ];
 
-    // TODO(eankeen): cleanup
     let p = await run([...cmd, "--check", ...files]);
-    console.log("DOO", p.stdout)
     assertEquals(p.code, 1);
     assertEquals(normalizeOutput(p.stdout), "Some files are not formatted");
 
-    console.log("FILES", files)
     p = await run([...cmd, "--write", ...files]);
     assertEquals(p.code, 0);
     assertEquals(

--- a/main_test.ts
+++ b/main_test.ts
@@ -44,216 +44,228 @@ function normalizeSourceCode(source: string): string {
   return source.replace(/\r/g, "");
 }
 
-test(async function testPrettierCheckAndFormatFiles(): Promise<void> {
-  const tempDir = await Deno.makeTempDir();
-  await copy(testdata, tempDir, { overwrite: true });
+test({
+  name: "testPrettierCheckAndFormatFiles",
+  async fn(): Promise<void> {
+    const tempDir = await Deno.makeTempDir();
+    await copy(testdata, tempDir, { overwrite: true });
 
-  const files = [
-    join(tempDir, "0.ts"),
-    join(tempDir, "1.js"),
-    join(tempDir, "2.ts"),
-    join(tempDir, "3.jsx"),
-    join(tempDir, "4.tsx")
-  ];
+    const files = [
+      join(tempDir, "0.ts"),
+      join(tempDir, "1.js"),
+      join(tempDir, "2.ts"),
+      join(tempDir, "3.jsx"),
+      join(tempDir, "4.tsx"),
+    ];
 
-  let p = await run([...cmd, "--check", ...files]);
-  assertEquals(p.code, 1);
-  assertEquals(normalizeOutput(p.stdout), "Some files are not formatted");
+    let p = await run([...cmd, "--check", ...files]);
+    assertEquals(p.code, 1);
+    assertEquals(normalizeOutput(p.stdout), "Some files are not formatted");
 
-  p = await run([...cmd, "--write", ...files]);
-  assertEquals(p.code, 0);
-  assertEquals(
-    normalizeOutput(p.stdout),
-    normalizeOutput(`Formatting ${tempDir}/0.ts
-Formatting ${tempDir}/1.js
-Formatting ${tempDir}/3.jsx
-Formatting ${tempDir}/4.tsx
-`)
-  );
+    p = await run([...cmd, "--write", ...files]);
+    assertEquals(p.code, 0);
+    assertEquals(
+      normalizeOutput(p.stdout),
+      normalizeOutput(`Formatting ${tempDir}/0.ts
+    Formatting ${tempDir}/1.js
+    Formatting ${tempDir}/3.jsx
+    Formatting ${tempDir}/4.tsx
+    `),
+    );
 
-  p = await run([...cmd, "--check", ...files]);
-  assertEquals(p.code, 0);
-  assertEquals(normalizeOutput(p.stdout), "Every file is formatted");
+    p = await run([...cmd, "--check", ...files]);
+    assertEquals(p.code, 0);
+    assertEquals(normalizeOutput(p.stdout), "Every file is formatted");
 
-  emptyDir(tempDir);
-});
+    emptyDir(tempDir);
+  }
+})
 
-test(async function testPrettierCheckAndFormatDirs(): Promise<void> {
-  const tempDir = await Deno.makeTempDir();
-  await copy(testdata, tempDir, { overwrite: true });
+test({
+  name: "testPrettierCheckAndFormatDirs",
+  async fn(): Promise<void> {
+    const tempDir = await Deno.makeTempDir();
+    await copy(testdata, tempDir, { overwrite: true });
 
-  const dirs = [join(tempDir, "foo"), join(tempDir, "bar")];
+    const dirs = [join(tempDir, "foo"), join(tempDir, "bar")];
 
-  let p = await run([...cmd, "--check", ...dirs]);
-  assertEquals(p.code, 1);
-  assertEquals(normalizeOutput(p.stdout), "Some files are not formatted");
+    let p = await run([...cmd, "--check", ...dirs]);
+    assertEquals(p.code, 1);
+    assertEquals(normalizeOutput(p.stdout), "Some files are not formatted");
 
-  p = await run([...cmd, "--write", ...dirs]);
-  assertEquals(p.code, 0);
-  assertEquals(
-    normalizeOutput(p.stdout),
-    normalizeOutput(`Formatting ${tempDir}/bar/0.ts
-Formatting ${tempDir}/bar/1.js
-Formatting ${tempDir}/foo/0.ts
-Formatting ${tempDir}/foo/1.js`)
-  );
+    p = await run([...cmd, "--write", ...dirs]);
+    assertEquals(p.code, 0);
+    assertEquals(
+      normalizeOutput(p.stdout),
+      normalizeOutput(`Formatting ${tempDir}/bar/0.ts
+    Formatting ${tempDir}/bar/1.js
+    Formatting ${tempDir}/foo/0.ts
+    Formatting ${tempDir}/foo/1.js`),
+    );
 
-  p = await run([...cmd, "--check", ...dirs]);
-  assertEquals(p.code, 0);
-  assertEquals(normalizeOutput(p.stdout), "Every file is formatted");
+    p = await run([...cmd, "--check", ...dirs]);
+    assertEquals(p.code, 0);
+    assertEquals(normalizeOutput(p.stdout), "Every file is formatted");
 
-  emptyDir(tempDir);
-});
+    emptyDir(tempDir);
+  }
+})
 
-test(async function testPrettierOptions(): Promise<void> {
-  const tempDir = await Deno.makeTempDir();
-  await copy(testdata, tempDir, { overwrite: true });
+test({
+  name: "testPrettierOptions",
+  async fn(): Promise<void> {
+    const tempDir = await Deno.makeTempDir();
+    await copy(testdata, tempDir, { overwrite: true });
 
-  const file0 = join(tempDir, "opts", "0.ts");
-  const file1 = join(tempDir, "opts", "1.ts");
-  const file2 = join(tempDir, "opts", "2.ts");
-  const file3 = join(tempDir, "opts", "3.md");
+    const file0 = join(tempDir, "opts", "0.ts");
+    const file1 = join(tempDir, "opts", "1.ts");
+    const file2 = join(tempDir, "opts", "2.ts");
+    const file3 = join(tempDir, "opts", "3.md");
 
-  const getSourceCode = async (f: string): Promise<string> =>
-    decoder.decode(await Deno.readFile(f));
+    const getSourceCode = async (f: string): Promise<string> =>
+      decoder.decode(await Deno.readFile(f));
 
-  await run([...cmd, "--no-semi", "--write", file0]);
-  assertEquals(
-    normalizeSourceCode(await getSourceCode(file0)),
-    `console.log(0)
-console.log([function foo() {}, function baz() {}, a => {}])
-`
-  );
+    await run([...cmd, "--no-semi", "--write", file0]);
+    assertEquals(
+      normalizeSourceCode(await getSourceCode(file0)),
+      `console.log(0)
+    console.log([function foo() {}, function baz() {}, a => {}])
+    `,
+    );
 
-  await run([
-    ...cmd,
-    "--print-width",
-    "30",
-    "--tab-width",
-    "4",
-    "--write",
-    file0
-  ]);
-  assertEquals(
-    normalizeSourceCode(await getSourceCode(file0)),
-    `console.log(0);
-console.log([
-    function foo() {},
-    function baz() {},
-    a => {}
-]);
-`
-  );
+    await run([
+      ...cmd,
+      "--print-width",
+      "30",
+      "--tab-width",
+      "4",
+      "--write",
+      file0,
+    ]);
+    assertEquals(
+      normalizeSourceCode(await getSourceCode(file0)),
+      `console.log(0);
+    console.log([
+        function foo() {},
+        function baz() {},
+        a => {}
+    ]);
+    `,
+    );
 
-  await run([...cmd, "--print-width", "30", "--use-tabs", "--write", file0]);
-  assertEquals(
-    normalizeSourceCode(await getSourceCode(file0)),
-    `console.log(0);
-console.log([
-	function foo() {},
-	function baz() {},
-	a => {}
-]);
-`
-  );
+    await run([...cmd, "--print-width", "30", "--use-tabs", "--write", file0]);
+    assertEquals(
+      normalizeSourceCode(await getSourceCode(file0)),
+      `console.log(0);
+    console.log([
+      function foo() {},
+      function baz() {},
+      a => {}
+    ]);
+    `,
+    );
 
-  await run([...cmd, "--single-quote", "--write", file1]);
-  assertEquals(
-    normalizeSourceCode(await getSourceCode(file1)),
-    `console.log('1');
-`
-  );
+    await run([...cmd, "--single-quote", "--write", file1]);
+    assertEquals(
+      normalizeSourceCode(await getSourceCode(file1)),
+      `console.log('1');
+    `,
+    );
 
-  await run([
-    ...cmd,
-    "--print-width",
-    "30",
-    "--trailing-comma",
-    "all",
-    "--write",
-    file0
-  ]);
-  assertEquals(
-    normalizeSourceCode(await getSourceCode(file0)),
-    `console.log(0);
-console.log([
-  function foo() {},
-  function baz() {},
-  a => {},
-]);
-`
-  );
+    await run([
+      ...cmd,
+      "--print-width",
+      "30",
+      "--trailing-comma",
+      "all",
+      "--write",
+      file0,
+    ]);
+    assertEquals(
+      normalizeSourceCode(await getSourceCode(file0)),
+      `console.log(0);
+    console.log([
+      function foo() {},
+      function baz() {},
+      a => {},
+    ]);
+    `,
+    );
 
-  await run([...cmd, "--no-bracket-spacing", "--write", file2]);
-  assertEquals(
-    normalizeSourceCode(await getSourceCode(file2)),
-    `console.log({a: 1});
-`
-  );
+    await run([...cmd, "--no-bracket-spacing", "--write", file2]);
+    assertEquals(
+      normalizeSourceCode(await getSourceCode(file2)),
+      `console.log({a: 1});
+    `,
+    );
 
-  await run([...cmd, "--arrow-parens", "always", "--write", file0]);
-  assertEquals(
-    normalizeSourceCode(await getSourceCode(file0)),
-    `console.log(0);
-console.log([function foo() {}, function baz() {}, (a) => {}]);
-`
-  );
+    await run([...cmd, "--arrow-parens", "always", "--write", file0]);
+    assertEquals(
+      normalizeSourceCode(await getSourceCode(file0)),
+      `console.log(0);
+    console.log([function foo() {}, function baz() {}, (a) => {}]);
+    `,
+    );
 
-  await run([...cmd, "--prose-wrap", "always", "--write", file3]);
-  assertEquals(
-    normalizeSourceCode(await getSourceCode(file3)),
-    "Lorem ipsum dolor sit amet, consectetur adipiscing elit, " +
-      "sed do eiusmod tempor" +
-      "\nincididunt ut labore et dolore magna aliqua.\n"
-  );
+    await run([...cmd, "--prose-wrap", "always", "--write", file3]);
+    assertEquals(
+      normalizeSourceCode(await getSourceCode(file3)),
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit, " +
+        "sed do eiusmod tempor" +
+        "\nincididunt ut labore et dolore magna aliqua.\n",
+    );
 
-  await run([...cmd, "--end-of-line", "crlf", "--write", file2]);
-  assertEquals(await getSourceCode(file2), "console.log({ a: 1 });\r\n");
+    await run([...cmd, "--end-of-line", "crlf", "--write", file2]);
+    assertEquals(await getSourceCode(file2), "console.log({ a: 1 });\r\n");
 
-  emptyDir(tempDir);
-});
+    emptyDir(tempDir);
+  }
+})
 
-test(async function testPrettierPrintToStdout(): Promise<void> {
-  const tempDir = await Deno.makeTempDir();
-  await copy(testdata, tempDir, { overwrite: true });
+test({
+  name: "testPrettierPrintToStdout",
+  async fn(): Promise<void> {
+    const tempDir = await Deno.makeTempDir();
+    await copy(testdata, tempDir, { overwrite: true });
 
-  const file0 = join(tempDir, "0.ts");
-  const file1 = join(tempDir, "formatted.ts");
+    const file0 = join(tempDir, "0.ts");
+    const file1 = join(tempDir, "formatted.ts");
 
-  const getSourceCode = async (f: string): Promise<string> =>
-    decoder.decode(await Deno.readFile(f));
+    const getSourceCode = async (f: string): Promise<string> =>
+      decoder.decode(await Deno.readFile(f));
 
-  const { stdout } = await run([...cmd, file0]);
-  // The source file will not change without `--write` flags.
-  assertEquals(
-    await getSourceCode(file0),
-    `console.log (0)
-`
-  );
-  // The output should be formatted code.
-  assertEquals(
-    stdout,
-    `console.log(0);
-`
-  );
+    const { stdout } = await run([...cmd, file0]);
+    // The source file will not change without `--write` flags.
+    assertEquals(
+      await getSourceCode(file0),
+      `console.log (0)
+    `,
+    );
+    // The output should be formatted code.
+    assertEquals(
+      stdout,
+      `console.log(0);
+    `,
+    );
 
-  const { stdout: formattedCode } = await run([...cmd, file1]);
-  // The source file will not change without `--write` flags.
-  assertEquals(
-    await getSourceCode(file1),
-    `console.log(0);
-`
-  );
-  // The output will be formatted code even it is the same as the source file's
-  // content.
-  assertEquals(
-    formattedCode,
-    `console.log(0);
-`
-  );
+    const { stdout: formattedCode } = await run([...cmd, file1]);
+    // The source file will not change without `--write` flags.
+    assertEquals(
+      await getSourceCode(file1),
+      `console.log(0);
+    `,
+    );
+    // The output will be formatted code even it is the same as the source file's
+    // content.
+    assertEquals(
+      formattedCode,
+      `console.log(0);
+    `,
+    );
 
-  emptyDir(tempDir);
-});
+    emptyDir(tempDir);
+  }
+})
 
 // TODO(bartlomieju): reenable after landing rusty_v8 branch
 // crashing on Windows
@@ -382,85 +394,129 @@ test(async function testPrettierReadFromStdin(): Promise<void> {
 });
 */
 
-test(async function testPrettierWithAutoConfig(): Promise<void> {
-  const configs = [
-    "config_file_json",
-    "config_file_toml",
-    "config_file_js",
-    "config_file_ts",
-    "config_file_yaml",
-    "config_file_yml"
-  ];
+test({
+  name: "testPrettierWithoutAutoConfig",
+  async fn(): Promise<void> {
+    const configs = [
+      "config_file_json",
+      "config_file_toml",
+      "config_file_js",
+      "config_file_ts",
+      "config_file_yaml",
+      "config_file_yml",
+    ];
 
-  for (const configName of configs) {
-    const cwd = join(testdata, configName);
-    const prettierFile = join(Deno.cwd(), "main.ts");
-    const { stdout, stderr } = Deno.run({
-      cmd: [
-        execPath(),
-        "run",
-        "--allow-read",
-        "--allow-env",
-        prettierFile,
-        "../5.ts",
-        "--config",
-        "auto"
-      ],
-      stdout: "piped",
-      stderr: "piped",
-      cwd
-    });
+    for (const configName of configs) {
+      const cwd = join(testdata, configName);
+      const prettierFile = join(Deno.cwd(), "main.ts");
+      const { stdout, stderr } = Deno.run({
+        cmd: [
+          execPath(),
+          "run",
+          "--allow-read",
+          "--allow-env",
+          prettierFile,
+          "../5.ts",
+          "--config",
+          "auto",
+        ],
+        stdout: "piped",
+        stderr: "piped",
+        cwd,
+      });
 
-    // TODO: Fix
-    const output = decoder.decode(await Deno.readAll(stdout as any));
-    const errMsg = decoder.decode(await Deno.readAll(stderr as any));
+      // TODO: Fix
+      const output = decoder.decode(await Deno.readAll(stdout as any));
+      const errMsg = decoder.decode(await Deno.readAll(stderr as any));
 
-    assertEquals(
-      errMsg
-        .split(EOL)
-        .filter((line: string) => line.indexOf("Compile") !== 0)
-        .join(EOL),
-      ""
-    );
+      assertEquals(
+        errMsg
+          .split(EOL)
+          .filter((line: string) => line.indexOf("Compile") !== 0)
+          .join(EOL),
+        "",
+      );
 
-    assertEquals(output, `console.log('0');\n`);
-  }
-});
-
-test(async function testPrettierWithSpecifiedConfig(): Promise<void> {
-  interface Config {
-    dir: string;
-    name: string;
-  }
-  const configs: Config[] = [
-    {
-      dir: "config_file_json",
-      name: ".prettierrc.json"
-    },
-    {
-      dir: "config_file_toml",
-      name: ".prettierrc.toml"
-    },
-    {
-      dir: "config_file_js",
-      name: ".prettierrc.js"
-    },
-    {
-      dir: "config_file_ts",
-      name: ".prettierrc.ts"
-    },
-    {
-      dir: "config_file_yaml",
-      name: ".prettierrc.yaml"
-    },
-    {
-      dir: "config_file_yml",
-      name: ".prettierrc.yml"
+      assertEquals(output, `console.log('0');\n`);
     }
-  ];
+  }
+})
 
-  for (const config of configs) {
-    const cwd = join(testdata, config.dir);
+test({
+  name: "testPrettierWithSpecifiedConfig",
+  async fn(): Promise<void> {
+    interface Config {
+      dir: string;
+      name: string;
+    }
+    const configs: Config[] = [
+      {
+        dir: "config_file_json",
+        name: ".prettierrc.json",
+      },
+      {
+        dir: "config_file_toml",
+        name: ".prettierrc.toml",
+      },
+      {
+        dir: "config_file_js",
+        name: ".prettierrc.js",
+      },
+      {
+        dir: "config_file_ts",
+        name: ".prettierrc.ts",
+      },
+      {
+        dir: "config_file_yaml",
+        name: ".prettierrc.yaml",
+      },
+      {
+        dir: "config_file_yml",
+        name: ".prettierrc.yml",
+      },
+    ];
+
+    for (const config of configs) {
+      const cwd = join(testdata, config.dir);
+      const prettierFile = join(Deno.cwd(), "main.ts");
+      const { stdout, stderr } = Deno.run({
+        cmd: [
+          execPath(),
+          "run",
+          "--allow-read",
+          "--allow-env",
+          prettierFile,
+          "../5.ts",
+          "--config",
+          config.name,
+        ],
+        stdout: "piped",
+        stderr: "piped",
+        cwd,
+      });
+
+      // TODO: Fix
+      const output = decoder.decode(await Deno.readAll(stdout as any));
+      const errMsg = decoder.decode(await Deno.readAll(stderr as any));
+
+      assertEquals(
+        errMsg
+          .split(EOL)
+          .filter((line: string) => line.indexOf("Compile") !== 0)
+          .join(EOL),
+        "",
+      );
+
+      assertEquals(output, `console.log('0');\n`);
+    }
+  }
+})
+
+test({
+  name: "testPrettierWithAutoIgnore",
+  async fn(): Promise<void> {
+    // only format typescript file
+    const cwd = join(testdata, "ignore_file");
     const prettierFile = join(Deno.cwd(), "main.ts");
     const { stdout, stderr } = Deno.run({
       cmd: [
@@ -469,83 +525,51 @@ test(async function testPrettierWithSpecifiedConfig(): Promise<void> {
         "--allow-read",
         "--allow-env",
         prettierFile,
-        "../5.ts",
-        "--config",
-        config.name
+        "**/*",
+        "--ignore-path",
+        "auto",
+      ],
+      stdout: "piped",
+      stderr: "piped",
+      cwd,
+    });
+
+    assertEquals(decoder.decode(await Deno.readAll(stderr as any)), "");
+
+    assertEquals(
+      decoder.decode(await Deno.readAll(stdout as any)),
+      `console.log("typescript");\nconsole.log("typescript1");\n`,
+    );
+  }
+})
+
+test({
+  name: "testPrettierWithSpecifiedIgnore",
+  async fn(): Promise<void> {
+    // only format javascript file
+    const cwd = join(testdata, "ignore_file");
+    const prettierFile = join(Deno.cwd(), "main.ts");
+    const { stdout, stderr } = Deno.run({
+      cmd: [
+        execPath(),
+        "run",
+        "--allow-read",
+        "--allow-env",
+        prettierFile,
+        "**/*",
+        "--ignore-path",
+        "typescript.prettierignore"
       ],
       stdout: "piped",
       stderr: "piped",
       cwd
     });
 
-    // TODO: Fix
-    const output = decoder.decode(await Deno.readAll(stdout as any));
-    const errMsg = decoder.decode(await Deno.readAll(stderr as any));
+    assertEquals(decoder.decode(await Deno.readAll(stderr as any)), "");
 
     assertEquals(
-      errMsg
-        .split(EOL)
-        .filter((line: string) => line.indexOf("Compile") !== 0)
-        .join(EOL),
-      ""
+      decoder.decode(await Deno.readAll(stdout as any)),
+      `console.log("javascript");\nconsole.log("javascript1");\n`
     );
-
-    assertEquals(output, `console.log('0');\n`);
   }
-});
-
-test(async function testPrettierWithAutoIgnore(): Promise<void> {
-  // only format typescript file
-  const cwd = join(testdata, "ignore_file");
-  const prettierFile = join(Deno.cwd(), "main.ts");
-  const { stdout, stderr } = Deno.run({
-    cmd: [
-      execPath(),
-      "run",
-      "--allow-read",
-      "--allow-env",
-      prettierFile,
-      "**/*",
-      "--ignore-path",
-      "auto"
-    ],
-    stdout: "piped",
-    stderr: "piped",
-    cwd
-  });
-
-  assertEquals(decoder.decode(await Deno.readAll(stderr as any)), "");
-
-  assertEquals(
-    decoder.decode(await Deno.readAll(stdout as any)),
-    `console.log("typescript");\nconsole.log("typescript1");\n`
-  );
-});
-
-test(async function testPrettierWithSpecifiedIgnore(): Promise<void> {
-  // only format javascript file
-  const cwd = join(testdata, "ignore_file");
-  const prettierFile = join(Deno.cwd(), "main.ts");
-  const { stdout, stderr } = Deno.run({
-    cmd: [
-      execPath(),
-      "run",
-      "--allow-read",
-      "--allow-env",
-      prettierFile,
-      "**/*",
-      "--ignore-path",
-      "typescript.prettierignore"
-    ],
-    stdout: "piped",
-    stderr: "piped",
-    cwd
-  });
-
-  assertEquals(decoder.decode(await Deno.readAll(stderr as any)), "");
-
-  assertEquals(
-    decoder.decode(await Deno.readAll(stdout as any)),
-    `console.log("javascript");\nconsole.log("javascript1");\n`
-  );
 });

--- a/main_test.ts
+++ b/main_test.ts
@@ -1,18 +1,17 @@
 // Copyright 2020 denolib maintainers. MIT license.
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
-import { test, runIfMain } from "https://deno.land/std/testing/mod.ts";
 import { copy, emptyDir } from "https://deno.land/std/fs/mod.ts";
 import { EOL, join } from "https://deno.land/std/path/mod.ts";
 import { xrun } from "./util.ts";
-const { readAll, execPath } = Deno;
+const { readAll, execPath, test } = Deno;
 
 const decoder = new TextDecoder();
 
 async function run(
-  args: string[]
+  cmd: string[]
 ): Promise<{ stdout: string; code: number | undefined }> {
-  const p = xrun({ args, stdout: "piped" });
+  const p = xrun({ cmd, stdout: "piped" });
 
   const stdout = decoder.decode(await readAll(p.stdout!));
   const { code } = await p.status();
@@ -397,7 +396,7 @@ test(async function testPrettierWithAutoConfig(): Promise<void> {
     const cwd = join(testdata, configName);
     const prettierFile = join(Deno.cwd(), "main.ts");
     const { stdout, stderr } = Deno.run({
-      args: [
+      cmd: [
         execPath(),
         "run",
         "--allow-read",
@@ -412,8 +411,9 @@ test(async function testPrettierWithAutoConfig(): Promise<void> {
       cwd
     });
 
-    const output = decoder.decode(await Deno.readAll(stdout));
-    const errMsg = decoder.decode(await Deno.readAll(stderr));
+    // TODO: Fix
+    const output = decoder.decode(await Deno.readAll(stdout as any));
+    const errMsg = decoder.decode(await Deno.readAll(stderr as any));
 
     assertEquals(
       errMsg
@@ -463,7 +463,7 @@ test(async function testPrettierWithSpecifiedConfig(): Promise<void> {
     const cwd = join(testdata, config.dir);
     const prettierFile = join(Deno.cwd(), "main.ts");
     const { stdout, stderr } = Deno.run({
-      args: [
+      cmd: [
         execPath(),
         "run",
         "--allow-read",
@@ -478,8 +478,9 @@ test(async function testPrettierWithSpecifiedConfig(): Promise<void> {
       cwd
     });
 
-    const output = decoder.decode(await Deno.readAll(stdout));
-    const errMsg = decoder.decode(await Deno.readAll(stderr));
+    // TODO: Fix
+    const output = decoder.decode(await Deno.readAll(stdout as any));
+    const errMsg = decoder.decode(await Deno.readAll(stderr as any));
 
     assertEquals(
       errMsg
@@ -498,7 +499,7 @@ test(async function testPrettierWithAutoIgnore(): Promise<void> {
   const cwd = join(testdata, "ignore_file");
   const prettierFile = join(Deno.cwd(), "main.ts");
   const { stdout, stderr } = Deno.run({
-    args: [
+    cmd: [
       execPath(),
       "run",
       "--allow-read",
@@ -513,10 +514,10 @@ test(async function testPrettierWithAutoIgnore(): Promise<void> {
     cwd
   });
 
-  assertEquals(decoder.decode(await Deno.readAll(stderr)), "");
+  assertEquals(decoder.decode(await Deno.readAll(stderr as any)), "");
 
   assertEquals(
-    decoder.decode(await Deno.readAll(stdout)),
+    decoder.decode(await Deno.readAll(stdout as any)),
     `console.log("typescript");\nconsole.log("typescript1");\n`
   );
 });
@@ -526,7 +527,7 @@ test(async function testPrettierWithSpecifiedIgnore(): Promise<void> {
   const cwd = join(testdata, "ignore_file");
   const prettierFile = join(Deno.cwd(), "main.ts");
   const { stdout, stderr } = Deno.run({
-    args: [
+    cmd: [
       execPath(),
       "run",
       "--allow-read",
@@ -541,12 +542,10 @@ test(async function testPrettierWithSpecifiedIgnore(): Promise<void> {
     cwd
   });
 
-  assertEquals(decoder.decode(await Deno.readAll(stderr)), "");
+  assertEquals(decoder.decode(await Deno.readAll(stderr as any)), "");
 
   assertEquals(
-    decoder.decode(await Deno.readAll(stdout)),
+    decoder.decode(await Deno.readAll(stdout as any)),
     `console.log("javascript");\nconsole.log("javascript1");\n`
   );
 });
-
-runIfMain(import.meta);

--- a/testdata/opts/0.ts
+++ b/testdata/opts/0.ts
@@ -2,5 +2,5 @@ console.log(0);
 console.log([
     function foo() {},
     function baz() {},
-    a => {}
+    (_: any) => {}
 ]);

--- a/util.ts
+++ b/util.ts
@@ -6,6 +6,6 @@ const { build, run } = Deno;
 export function xrun(opts: Deno.RunOptions): Deno.Process {
   return run({
     ...opts,
-    args: build.os === "win" ? ["cmd.exe", "/c", ...opts.args] : opts.args
+    cmd: build.os === "win" ? ["cmd.exe", "/c", ...opts.cmd] : opts.cmd
   });
 }

--- a/util.ts
+++ b/util.ts
@@ -6,6 +6,6 @@ const { build, run } = Deno;
 export function xrun(opts: Deno.RunOptions): Deno.Process {
   return run({
     ...opts,
-    cmd: build.os === "win" ? ["cmd.exe", "/c", ...opts.cmd] : opts.cmd
+    cmd: build.os === "windows" ? ["cmd.exe", "/c", ...opts.cmd] : opts.cmd
   });
 }


### PR DESCRIPTION
this builds on top of @KSXGitHub's efforts to migrate the codebase to deno v0.40.0 (more specifically i'm on 0.42.0 as of writing this). if complete, it would fix #1

running `deno test` seems to almost works (it looks like most test should pass), but the main problem is that the tests 'leak async operations' due to non-awaited deno apis. i couldn't exactly find these non-awaited promises, so i'm making a draft pr here in case someone wants to pick up on it.

below is an excerpt of the errors i'm referring to. they show on nearly all tests.

```txt
testPrettierCheckAndFormatFiles
Error: Test case is leaking async ops.
Before:
  - dispatched: 1
  - completed: 1
After:
  - dispatched: 124
  - completed: 123
  
Make sure to await all promises returned from Deno APIs before 
finishing test case.
    at Object.assert ($deno$/util.ts:25:11)
    at asyncOpSanitizer ($deno$/testing.ts:46:5)
    at async Object.resourceSanitizer [as fn] ($deno$/testing.ts:70:5)
    at async TestApi.[Symbol.asyncIterator] ($deno$/testing.ts:264:11)
    at async Object.runTests ($deno$/testing.ts:346:20)

testPrettierCheckAndFormatDirs
Error: Test case is leaking resources.
Before: {
  "0": "stdin",
  "1": "stdout",
  "2": "stderr",
  "3": "childStdout",
  "4": "child",
  "5": "childStdout",
  "6": "child",
  "7": "childStdout",
  "8": "child"
}
After: {
  "0": "stdin",
  "1": "stdout",
  "2": "stderr",
  "3": "childStdout",
  "4": "child",
  "5": "childStdout",
  "6": "child",
  "7": "childStdout",
  "8": "child",
  "9": "childStdout",
  "10": "child",
  "11": "childStdout",
  "12": "child",
  "13": "childStdout",
  "14": "child"
}
```